### PR TITLE
Sort blog posts by date (newest first)

### DIFF
--- a/src/app/pages/blog/index.page.ts
+++ b/src/app/pages/blog/index.page.ts
@@ -41,5 +41,6 @@ import { RouterLink } from '@angular/router';
     ]
 })
 export default class BlogComponent {
-  readonly posts = injectContentFiles<PostAttributes>();
+  readonly posts = injectContentFiles<PostAttributes>()
+    .sort((a, b) => b.attributes.slug.localeCompare(a.attributes.slug));
 }


### PR DESCRIPTION
## Summary
- Adds `.sort()` to `injectContentFiles()` in the blog index page so posts render newest → oldest
- Sort is by slug descending — slugs start with `YYYY-MM-DD`, so alphabetical descending equals chronological descending
- Ensures "Generalist by Birth" (slug `2025-08-15-...`) always appears at the bottom

## Test plan
- [ ] Visit `/blog` and confirm post order: T1213 → Claude Code LLM → Generalist by Birth
- [ ] Adding future posts with date-prefixed slugs should automatically sort correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)